### PR TITLE
Scottdavis08 c14 60 standardize line endings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
   },
   "plugins": ["react", "react-native", "@typescript-eslint", "prettier"],
   "rules": {
-    "indent": ["error", 2], 
+    "indent": ["error", 2],
     "semi": ["error", "always"],
     "no-console": ["warn", { "allow": ["log", "error"] }],
     "prettier/prettier": "error",

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Enforce LF line endings for all text files
+* text= auto eol=LF
+
+# Specific overrides
+*.toml text eol=LF
+*.json text eol=LF
+*.ts text eol=LF

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ yarn-error.*
 # typescript
 *.tsbuildinfo
 
-package-lock.json
+debug.log

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -6,5 +6,6 @@
   "trailingComma": "all",
   "jsxSingleQuote": true,
   "bracketSpacing": true,
-  "useTabs": false
+  "useTabs": false,
+  "endOfLine": "lf"
 }


### PR DESCRIPTION
Unfortunately prettier like LF, but git (on windows) applies CRLF for line endings on text files.

LF is the better choice for longevity and being more universally applied to all OS's, so this should now force git to apply LF exclusively to this half of the project.

To test please run prettier (which has been set to always use LF, and already did so by default), and make sure no files are changed, which means the repo is already set up with LF only line endings.
