### PR TITLE
Fix former category landing page rename to Itesms and update navigati…

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -44,6 +44,7 @@ const linking: LinkingOptions<RootStackParamList> = {
       Login: 'login',
       Register: 'register',
       BodyScan: 'bodyscan',
+      Items: 'items',
     },
   },
   enabled: true,
@@ -116,6 +117,11 @@ function AppContent() {
               name='ItemDetails'
               component={ItemDetails}
               options={{ title: 'Item Details' }}
+            />
+            <Stack.Screen
+              name='Items'
+              component={Items}
+              options={{ title: 'Items' }}
             />
             <Stack.Screen
               name='Customization'

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -139,7 +139,7 @@ export default function HomeScreen({ navigation }: HomeScreenProps) {
 
         <TouchableOpacity
           style={styles.startShoppingButton}
-          onPress={() => navigation.navigate('Category', { slug: '1' })}
+          onPress={() => navigation.navigate('Items', { slug: 'all' })}
         >
           <Text style={styles.startShoppingText}>Start Shopping</Text>
         </TouchableOpacity>

--- a/src/screens/Items.tsx
+++ b/src/screens/Items.tsx
@@ -48,7 +48,9 @@ export default function Items({ navigation }: any) {
 
   // Filter items for this category
   const categoryItems = useMemo(
-    () => itemsData.filter((item) => item.categoryId === categoryId),
+    () => categoryId === 'all' 
+      ? itemsData // Show all items when slug is 'all'
+      : itemsData.filter((item) => item.categoryId === categoryId),
     [categoryId],
   );
 

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -4,6 +4,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 export type RootStackParamList = {
   Home: undefined;
   Category: { slug: string };
+  Items: { slug: string };
   BodyScan: undefined;
   Login: { email?: string } | undefined;
   Register: undefined;


### PR DESCRIPTION
Navigate to Items page on press 'start shopping' button and change names to match this throughout.
https://linear.app/c14-p3-renewu/issue/C14-82/change-navigator-component-name-to-match-new-landing-page-name